### PR TITLE
Restores 'Targets' menu tab

### DIFF
--- a/templates/tom_common/navbar_content.html
+++ b/templates/tom_common/navbar_content.html
@@ -9,6 +9,22 @@ For customization instructions, see tom_common/base.html
 </li>
 
 <li class="nav-item dropdown">
+    <a class="nav-link dropdown-toggle" data-toggle="dropdown">Targets</a>
+    <ul class="dropdown-menu">
+        <li class="nav-item {% if request.resolver_match.namespace == 'targets' %}active{% endif %}">
+            <a class="nav-link" href="{% url 'targets:list' %}">
+                <font color="black">Targets</font>
+            </a>
+        </li>
+        <li class="nav-item {% if request.resolver_match.namespace == 'targets' %}active{% endif %}">
+            <a class="nav-link" href="{% url 'targets:targetgrouping' %}">
+                <font color="black">Target Grouping</font>
+            </a>
+        </li>
+    </ul>
+</li>
+
+<li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" data-toggle="dropdown">Observations</a>
     <ul class="dropdown-menu">
         <li class="nav-item {% if request.resolver_match.namespace == 'observations' %}active{% endif %}">


### PR DESCRIPTION
I accidentally removed the `Targets` tab from the navbar. This PR restores it.